### PR TITLE
inflate: fix bug with longest distances

### DIFF
--- a/src/inflate.c
+++ b/src/inflate.c
@@ -378,24 +378,24 @@ static int8_t deflate_static_huffman()
 	for (i = 280; i <= 287; i++) {
 		deflate_lld_lengths[i] = 8;
 	}
-	for (i = 288; i <= 288 + 29; i++) {
+	for (i = 288; i < 288 + 30; i++) {
 		deflate_lld_lengths[i] = 5;
 	}
 
 #ifdef DEFLATE_WITH_LUT
 	deflate_build_alphabet(deflate_lld_lengths, 288, deflate_bl_count_ll,
 			       deflate_next_code_ll, deflate_ll_codes);
-	deflate_build_alphabet(deflate_lld_lengths + 288, 29,
+	deflate_build_alphabet(deflate_lld_lengths + 288, 30,
 			       deflate_bl_count_d, deflate_next_code_d,
 			       deflate_d_codes);
 	return deflate_huffman(deflate_ll_codes, deflate_d_codes);
 #else
 	deflate_build_alphabet(deflate_lld_lengths, 288, deflate_bl_count_ll,
 			       deflate_next_code_ll);
-	deflate_build_alphabet(deflate_lld_lengths + 288, 29,
+	deflate_build_alphabet(deflate_lld_lengths + 288, 30,
 			       deflate_bl_count_d, deflate_next_code_d);
 	return deflate_huffman(deflate_lld_lengths, 288,
-			       deflate_lld_lengths + 288, 29);
+			       deflate_lld_lengths + 288, 30);
 #endif
 }
 

--- a/test/inflate-app.c
+++ b/test/inflate-app.c
@@ -3,9 +3,19 @@
 
 #include "inflate.h"
 
+static int read_til_eof(unsigned char* into, size_t len, FILE* f) {
+  int bytes_read = 0;
+  while (!feof(f) && !ferror(f)) {
+    bytes_read += fread(into, 1, len - bytes_read, f);
+  }
+  if (ferror(f)) {
+    bytes_read = 0;
+  }
+  return bytes_read;
+}
+
 int main(int argc, char** argv)
 {
-
 	// 16 MB
 	unsigned char *inbuf = (unsigned char*)malloc(4096 * 4096);
 	unsigned char *outbuf = (unsigned char*)malloc(4096 * 4096);
@@ -22,7 +32,7 @@ int main(int argc, char** argv)
           if (!dict_buf || !dict_file) {
             return 1;
           }
-          dict_size = fread(dict_buf, 1, 4096 * 4096, dict_file);
+          dict_size = read_til_eof(dict_buf, 4096 * 4096, dict_file);
           if (dict_size <= 0) {
             return 1;
           }
@@ -30,7 +40,7 @@ int main(int argc, char** argv)
           fclose(dict_file);
         }
 
-	size_t in_size = fread(inbuf, 1, 4096 * 4096, stdin);
+	size_t in_size = read_til_eof(inbuf, 4096 * 4096, stdin);
 
 	if (in_size == 0) {
 		return 1;


### PR DESCRIPTION
Fix a bug where the longest distance codes were invalid. Also make sure we read all of the files/stdin in the tests.